### PR TITLE
Add test for error handling in episodes api

### DIFF
--- a/ex-11/got-episodes-api-python/src/controller/episodes_controller.py
+++ b/ex-11/got-episodes-api-python/src/controller/episodes_controller.py
@@ -1,5 +1,5 @@
-import requests
 from fastapi import HTTPException
+from requests import get
 from typing import List
 from data.models import Episode
 from data.got_demo_data import episodes
@@ -15,10 +15,13 @@ def get_random_quote(obo_token: str):
     config = get_settings()
     quote_endpoint = f"{ config.quotes_api_url }api/quote"
     quote_headers = {"Authorization": f"Bearer {obo_token}"}
-    logger.warning(f"{quote_endpoint = }")
-    quote = requests.get(url= quote_endpoint, headers = quote_headers)
-    logger.info(f"Got a quote: {quote} {repr(quote)}")
-    return quote.json()
+    logger.info(f"{quote_endpoint = }")
+    try:
+        quote = get(url= quote_endpoint, headers = quote_headers).json()
+        logger.info(f"Got a quote: {quote} {repr(quote)}")
+    except Exception:
+        quote = {"title": "Quote error"}
+    return quote
 
 def get_episode(episode_id: str) -> Episode:
     episode = next((ep for ep in episodes if ep['id'] == episode_id), None)

--- a/ex-11/got-episodes-api-python/tests/controller/test_episodes_controller.py
+++ b/ex-11/got-episodes-api-python/tests/controller/test_episodes_controller.py
@@ -1,10 +1,12 @@
 import pytest
-from controller.episodes_controller import get_all_episodes, get_episode, add_episode, update_episode, delete_episode
+from unittest.mock import Mock
+from controller.episodes_controller import get_all_episodes, get_episode, add_episode, update_episode, delete_episode, get_random_quote
 from data.got_demo_data import episodes
 from data.models import Episode
 
 @pytest.fixture
 def patchenv(monkeypatch):
+    monkeypatch.setenv('QUOTES_API_URL', 'https://test_quotes_api.url')
     test_episodes = [
         {"id": "1", "title": 'Winter is coming',                        "season": 1},
         {"id": "2", "title": 'The Kingsroad',                           "season": 1},
@@ -17,8 +19,14 @@ def patchenv(monkeypatch):
         {"id": "9", "title": 'Bealor',                                  "season": 1},
         {"id": "10", "title": 'Fire and Blood',                          "season": 1},
     ]    
-    monkeypatch.setattr("data.got_demo_data.episodes", test_episodes)
     monkeypatch.setattr("controller.episodes_controller.episodes", test_episodes)
+
+    def mock_requests_get(*args, **kwargs):
+        mock_response = Mock()
+        mock_response.json.side_effect = Exception("Triggered exception")
+        return mock_response
+    monkeypatch.setattr("controller.episodes_controller.get", mock_requests_get)    
+    
     yield monkeypatch    
 
 def test_get_all_episodes(patchenv):
@@ -56,3 +64,6 @@ def test_delete_episode(patchenv):
     with pytest.raises(Exception):
         get_episode(episode_id)
 
+def test_get_random_quote(patchenv):
+    quote = get_random_quote("test_obo_token")
+    assert quote == {"title": "Quote error"}

--- a/ex-11/got-episodes-api-python/tests/controller/test_episodes_controller.py
+++ b/ex-11/got-episodes-api-python/tests/controller/test_episodes_controller.py
@@ -7,6 +7,11 @@ from data.models import Episode
 @pytest.fixture
 def patchenv(monkeypatch):
     monkeypatch.setenv('QUOTES_API_URL', 'https://test_quotes_api.url')
+    monkeypatch.setenv('TENANT_ID', '123')
+    monkeypatch.setenv('CLIENT_ID', '123')
+    monkeypatch.setenv('CLIENT_SECRET', '123')
+    monkeypatch.setenv('EPISODES_API_URI', 'api://123')
+    monkeypatch.setenv('QUOTES_API_URI', 'api://123')
     test_episodes = [
         {"id": "1", "title": 'Winter is coming',                        "season": 1},
         {"id": "2", "title": 'The Kingsroad',                           "season": 1},

--- a/ex-11/got-episodes-api-python/tests/core/test_core.py
+++ b/ex-11/got-episodes-api-python/tests/core/test_core.py
@@ -16,7 +16,7 @@ def patchenv(monkeypatch):
     monkeypatch.setenv('QUOTES_API_URI', 'test_quotes_api_uri')
     monkeypatch.setenv('PORT', '7777')
     monkeypatch.setenv('HOST', 'test_host')
-
+    
     yield monkeypatch
 
 def test_valid_app_settings(patchenv):
@@ -35,7 +35,8 @@ def test_valid_app_settings(patchenv):
     assert config.api_audience == f"api://{config.episodes_api_uri}"
     assert config.issuer == HttpUrl(f"https://sts.windows.net/{config.tenant_id}/")
 
-def test_missing_environment_variables():
+def test_missing_environment_variables(patchenv):
+    patchenv.delenv('TENANT_ID')
     with pytest.raises(KeyError):
         get_settings()
 

--- a/ex-11/got-quote-api-dotnet/src/utils/TokenValidator.cs
+++ b/ex-11/got-quote-api-dotnet/src/utils/TokenValidator.cs
@@ -43,19 +43,16 @@ public class TokenValidator : ITokenValidator
         {
             // Check issuer
             if (jwtToken.Issuer != validationParameters.ValidIssuer) {
-                _logger.LogError("Issuer is invalid");
                 throw new SecurityTokenInvalidIssuerException("Issuer is invalid");
             };
 
             // Check audience
             if (jwtToken.Audiences.All(a => a != validationParameters.ValidAudience)) {
-                _logger.LogError("Audience is invalid");
                 throw new SecurityTokenInvalidAudienceException("Audience is invalid");
             };
 
             // Check signature and validate
             if (!validationParameters.IssuerSigningKeys.Any()) {
-                _logger.LogError("Signing key is invalid");
                 throw new SecurityTokenInvalidSigningKeyException("No signing keys!");
             };
             var validationParametersWithSigningKey = new TokenValidationParameters
@@ -70,13 +67,11 @@ public class TokenValidator : ITokenValidator
 
             // Check valid timeframes
             if (jwtToken.ValidFrom > DateTime.UtcNow || jwtToken.ValidTo < DateTime.UtcNow) {
-                _logger.LogError("Token is not valid in timeframe");
                 throw new SecurityTokenInvalidLifetimeException("Token is not valid in timeframe");
             };
 
             // Check scope
             if (jwtToken.Claims.All(c => c.Type != "scp" || !c.Value.Split(' ').Any(s => s == "Quote.Read"))) {
-                _logger.LogError("Token does not contain correct scope");
                 throw new SecurityTokenInvalidLifetimeException("Token does not contain correct scope");
             };
 


### PR DESCRIPTION
Closing #7 

This PR 
- Adds a test to ensure `got-episodes-api` handles errors from `got-quote-api`
- Prevents side-effects on environment variables when running `test_missing_environment_variables` by using patched environment variables
- Add some patched environment variables for `test_expisodes` for it to run without using real environment variables
- Pass on all signing keys to Tokenvalidator, not just the first one