### PR TITLE
chore(docs): replace custom path reference with simple $HOME

### DIFF
--- a/ex-02/doc/secrets.md
+++ b/ex-02/doc/secrets.md
@@ -21,7 +21,7 @@ Steps:
 
   ```shell
   cd ex-02
-  source ~/path-to-env-file/appsec-course-client-eq.env
+  source $HOME/envs/appsec-course-client-eq.env
   npm start
   ```
 * Once the needed config is saved into the .env file we can delete the Codespace user secret for Client Secret.

--- a/ex-04/doc/running_the_application.md
+++ b/ex-04/doc/running_the_application.md
@@ -9,7 +9,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-client-eq.env
+    source $HOME/envs/appsec-course-client-eq.env
     ```
 
 * Run the application 

--- a/ex-05/doc/running_the_application.md
+++ b/ex-05/doc/running_the_application.md
@@ -9,7 +9,7 @@ Steps:
 * Source the configuration file</br>(`aa-create-env-files-from-github-user-secret.sh` may be helpful if you have lost the config)
   
     ```shell
-    source ~/path-to-env-file/appsec-course-client-eq.env
+    source $HOME/envs/appsec-course-client-eq.env
     ```
 
 * Run the application 

--- a/ex-09/doc/running_the_application.md
+++ b/ex-09/doc/running_the_application.md
@@ -9,7 +9,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-client-eq.env
+    source $HOME/envs/appsec-course-client-eq.env
     ```
 
 * Run the application

--- a/ex-10/doc/configure_client_anda_api.md
+++ b/ex-10/doc/configure_client_anda_api.md
@@ -10,7 +10,7 @@ The readme.md file for both component include the basic information on which con
 
 ### Environment config
 
-For the client you have already crated a **.env** file that contains the basic configuration (~/path-to-env-file/appsec-course-client-eq.env). We need to add an additional variable for the MSAL token cache. This file now should hold the following environment parameters:
+For the client you have already crated a **.env** file that contains the basic configuration ($HOME/envs/appsec-course-client-eq.env). We need to add an additional variable for the MSAL token cache. This file now should hold the following environment parameters:
 
 ```shell
 export NODE_ENV=development

--- a/ex-10/doc/execute_client_and_api.md
+++ b/ex-10/doc/execute_client_and_api.md
@@ -12,7 +12,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-api-episodes-eq.env 
+    source $HOME/envs/appsec-course-api-episodes-eq.env 
     ```
 
 * Run the application 
@@ -41,7 +41,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-client-eq.env
+    source $HOME/envs/appsec-course-client-eq.env
     ```
 
 * Run the application

--- a/ex-10/doc/swapping_tech_for_episodes_api.md
+++ b/ex-10/doc/swapping_tech_for_episodes_api.md
@@ -59,7 +59,7 @@ Steps:
 - Source your configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-api-episodes-eq.env 
+    source $HOME/envs/appsec-course-api-episodes-eq.env 
     ```
 - Start the Python Api
 

--- a/ex-11/doc/client_code_config.md
+++ b/ex-11/doc/client_code_config.md
@@ -48,7 +48,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-client-eq.env 
+    source $HOME/envs/appsec-course-client-eq.env 
     ```
 
 * Run the application

--- a/ex-11/doc/quotes_code_config.md
+++ b/ex-11/doc/quotes_code_config.md
@@ -82,7 +82,7 @@ Steps:
 * Source the configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-api-quotes-eq.env
+    source $HOME/envs/appsec-course-api-quotes-eq.env
     ```
 
 * Run the application

--- a/ex-11/doc/swapping_tech_for_episodes_api.md
+++ b/ex-11/doc/swapping_tech_for_episodes_api.md
@@ -57,7 +57,7 @@ Steps:
 - Source your configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-api-episodes-eq.env
+    source $HOME/envs/appsec-course-api-episodes-eq.env
     ```
 - Start the Python Api
 

--- a/ex-11/doc/swapping_tech_for_quotes_api.md
+++ b/ex-11/doc/swapping_tech_for_quotes_api.md
@@ -62,7 +62,7 @@ Steps:
 - Source your configuration file
 
     ```shell
-    source ~/path-to-env-file/appsec-course-api-quotes-eq.env 
+    source $HOME/envs/appsec-course-api-quotes-eq.env 
     ```
 - Start the .Net Api
 


### PR DESCRIPTION
It is easy to overlook the `path-to-env-file` in the command path while following the guide and copying the commands to run in the terminal, which can cause issues and take time away from the workshop.

Simple reference to `$HOME` will fix the issue.