### PR TITLE
Update dotnet libraries in Quote

### DIFF
--- a/ex-11/got-quote-api-dotnet/src/got-quote-api-dotnet.csproj
+++ b/ex-11/got-quote-api-dotnet/src/got-quote-api-dotnet.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.15.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.18.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     
   </ItemGroup>
 

--- a/ex-11/got-quote-api-dotnet/tests/got-quote-api-dotnet-test.csproj
+++ b/ex-11/got-quote-api-dotnet/tests/got-quote-api-dotnet-test.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="moq" Version="4.20.69" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="moq" Version="4.20.70" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
1. Upgraded libraries to remove medium severity warnings in main project
   
   
<img width="693" alt="image" src="https://github.com/equinor/appsec-fundamentals-authn-authz-cs/assets/1442452/f2971cdd-e7a3-4164-bcc6-f05528507800">
   
   
2. Upgraded libraries to remove medium severity warnings in test project

<img width="758" alt="image" src="https://github.com/equinor/appsec-fundamentals-authn-authz-cs/assets/1442452/037ed5f1-adfb-42f0-8504-80e2353ee0de">
   
   
3. Running tests `OK`:   
https://github.com/equinor/appsec-fundamentals-authn-authz-cs/blob/main/ex-11/got-quote-api-dotnet/readme.md
   
   
4. Manual e2e tests validated `OK` running with `client` and `episodes-api` after the upgrade

