### PR TITLE
Adjustments

### DIFF
--- a/docs/content/the_basics_of_aanda_2.md
+++ b/docs/content/the_basics_of_aanda_2.md
@@ -166,5 +166,5 @@ dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
 * The process for a protected resource to query the authorization server to verify validity of a OAuth2 token
 * An extension to OAuth2 defined in [rfc7662](https://datatracker.ietf.org/doc/html/rfc7662)
 * Getting tokens type by ref and querying for "details"
-* Not currently supported by Microsoft Entra ID<br/> ([5+ year old request](https://feedback.azure.com/d365community/idea/ea407180-be25-ec11-b6e6-000d3a4f0789))
+* Not currently supported by Microsoft Entra ID<br/> ([7+ year old request](https://feedback.azure.com/d365community/idea/ea407180-be25-ec11-b6e6-000d3a4f0789))
 * No introspection limits the value of the /revoke end-point?

--- a/ex-01/doc/requesting_an_access_token.md
+++ b/ex-01/doc/requesting_an_access_token.md
@@ -6,7 +6,6 @@ Steps:
 
 * Explore the `POST` request in 'authCode.http'
 * Copy the one-time `Code` from previous exercise (leg 1) to `&code=` of the post request
-* Copy the client_secret value into the "clip-board"
 * Select "Send the request" in VSCode (just above the POST definition)
 * Explore the results in the 'Response window'
   

--- a/ex-02/package-lock.json
+++ b/ex-02/package-lock.json
@@ -2581,9 +2581,10 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-querystring": "^1.0.0",
@@ -4380,10 +4381,11 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-            "dev": true
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",

--- a/ex-04/doc/security_considerations.md
+++ b/ex-04/doc/security_considerations.md
@@ -12,7 +12,7 @@ In this section we will discuss a few security related implication that we are f
 * [OAuth 2.0 for Browser-Based Apps](https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps/)
 * Good practice: Protocols (and Frameworks) does not guarantee security, Developers Do 
 * Good practice: For Microsoft Frameworks, Use MSAL (v2) - not ADAL (v1 is deprecated)
-* Good practice: Practice continuos threat modeling. Visit [appsec.equinor.com](https://appsec.equinor.com/threat-modeling/) for more information. ⚡️
+* Good practice: Practice continuous threat modeling. Visit [appsec.equinor.com](https://appsec.equinor.com/threat-modeling/) for more information. ⚡️
 
 ## --Now You--
 

--- a/ex-04/package-lock.json
+++ b/ex-04/package-lock.json
@@ -2569,9 +2569,10 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-querystring": "^1.0.0",
@@ -4321,10 +4322,11 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-            "dev": true
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",

--- a/ex-05/package-lock.json
+++ b/ex-05/package-lock.json
@@ -2831,9 +2831,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4759,9 +4759,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/ex-09/package-lock.json
+++ b/ex-09/package-lock.json
@@ -2831,9 +2831,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4759,9 +4759,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/ex-10/client/package-lock.json
+++ b/ex-10/client/package-lock.json
@@ -2853,9 +2853,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4805,9 +4805,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/ex-10/got-episodes-api/package-lock.json
+++ b/ex-10/got-episodes-api/package-lock.json
@@ -2795,9 +2795,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4669,9 +4669,9 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/ex-11/client/package-lock.json
+++ b/ex-11/client/package-lock.json
@@ -2854,9 +2854,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4806,9 +4806,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/ex-11/got-episodes-api/package-lock.json
+++ b/ex-11/got-episodes-api/package-lock.json
@@ -2897,9 +2897,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -4892,9 +4892,9 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
         },


### PR DESCRIPTION
This PR fixes two NPM reported high secerity vulnerabilities in addition to small spellings

```sh
▶ npm audit
# npm audit report

find-my-way  <8.2.2
Severity: high
find-my-way has a ReDoS vulnerability in multiparametric routes - https://github.com/advisories/GHSA-rrr8-f88r-h8q6

path-to-regexp  4.0.0 - 6.2.2
Severity: high
path-to-regexp outputs backtracking regular expressions - https://github.com/advisories/GHSA-9wv6-86v2-598j
```