### PR TITLE
Fix timeframe and one npm vulnerabilities

### DIFF
--- a/ex-01/doc/request_an_authorization_code.md
+++ b/ex-01/doc/request_an_authorization_code.md
@@ -22,7 +22,7 @@ Steps:
   * Using the Browser Web Developer Tools is recommended.
   * Why in the browser?
   * Why the "consent" flow?
-  * The code is available in the redirect. It is "use once" within "seconds"
+  * The code is available in the redirect. It is "use once" within 10 minutes
   * (Depending on the State of your browser you may have to authenticate or not, explore the get request header for cookies)
   * Make a copy of the 'code' parameter in the redirect.
 * For additional insight on the complete dance (optional)

--- a/ex-11/got-quote-api/package-lock.json
+++ b/ex-11/got-quote-api/package-lock.json
@@ -2706,10 +2706,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-            "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
-            "license": "MIT",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+            "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-querystring": "^1.0.0",
@@ -4541,11 +4540,10 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",


### PR DESCRIPTION
Using time duration from documentation for authorization code
https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#successful-response

This PR will also remove the following npm vulnerabilities
```sh
find-my-way  <8.2.2
Severity: high
find-my-way has a ReDoS vulnerability in multiparametric routes - https://github.com/advisories/GHSA-rrr8-f88r-h8q6
fix available via `npm audit fix`
node_modules/find-my-way

path-to-regexp  4.0.0 - 6.2.2
Severity: high
path-to-regexp outputs backtracking regular expressions - https://github.com/advisories/GHSA-9wv6-86v2-598j
fix available via `npm audit fix`
node_modules/path-to-regexp

2 high severity vulnerabilities
```