### PR TITLE
Adjustments pre run 11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 		"ghcr.io/devcontainers/features/dotnet",
 		"ghcr.io/devcontainers/features/node",
 		"ghcr.io/devcontainers/features/python",
-		"ghcr.io/devcontainers/features/github-cli",
+		"ghcr.io/devcontainers/features/github-cli"
 	],
 	"customizations": {
 		"vscode": {
@@ -44,14 +44,11 @@
 				"dbaeumer.vscode-eslint",
 				"ms-azuretools.vscode-docker",
 				"charliermarsh.ruff",
-				"ms-dotnettools.csharp",
-				"ritwickdey.liveserver"
+				"ms-dotnettools.csharp"
 			],
 			"settings": {
 				"gitlens.showWelcomeOnInstall": false,
-				"terminal.integrated.gpuAcceleration": "canvas",
-				"liveServer.settings.root": "/docs",
-				"liveServer.settings.donotShowInfoMsg": true,
+				"terminal.integrated.gpuAcceleration": "auto",
 				"terminal.integrated.shell.linux": "/usr/bin/zsh",
 				"terminal.integrated.defaultProfile.linux": "zsh",
 				"csharp.suppressBuildAssetsNotification": true

--- a/ex-11/got-quote-api/test/app.test.js
+++ b/ex-11/got-quote-api/test/app.test.js
@@ -37,18 +37,18 @@ test('requests the swagger "/doc" route', async (t) => {
             method: 'GET',
             url: '/doc',
         });
-        t.equal(response.statusCode, 302, 'returns a status code of 302');
-        t.equal(response.headers.location,'./doc/static/index.html','location is to static html');
+        t.equal(response.statusCode, 200, 'returns a status code of 200');
         t.end();
-
+        
     });
-
+    
     t.test('Request to /doc/static/index.html should render swagger doc', async (t) => {
         const response = await app.inject({
             method: 'GET',
             url: '/doc/static/index.html',
         });
-        t.equal(response.statusCode, 200, 'returns a status code of 200');
+        t.equal(response.statusCode, 302, 'returns a status code of 302');
+        t.equal(response.headers.location,'/doc/','location is to static html');
    
         t.end();
     });


### PR DESCRIPTION
Changes:

- `got-episodes` in `ex-10` and `ex-11` was already patched, but not `got-quote` in `ex-11`. This has now been fixed.
- `ritwickdey.liveserver` has been removed from `devcontainer.json` (not currently in use in WS)
- corrected value on attribute `terminal.integrated.gpuAcceleration` to `auto`

Test details:
<img width="968" alt="image" src="https://github.com/user-attachments/assets/8903d5f0-e8b7-4292-a573-f7682682a704">
